### PR TITLE
Add test to reproduce failure

### DIFF
--- a/test/02-api.janet
+++ b/test/02-api.janet
@@ -9,8 +9,8 @@
 (assert (date/tm? loc))
 (assert (= (:mktime loc) (:timegm gmt)))
 
-(def before (date/update-time* now {:sec -1 :min dec}))
-(def after  (date/update-time* now {:sec 61 :min inc}))
+(def before (date/update-time now :sec -1 :min dec))
+(def after (date/update-time now :sec 61 :min inc))
 (assert (> after now before))
 
 # default format
@@ -21,7 +21,7 @@
 (assert (date/format now :%c))
 
 # ensure tm + gmtime are spec-compliant
-(def u (date/utc   {:year 1970}))
+(def u (date/utc {:year 1970}))
 (def l (date/local {:year 1970}))
 (assert (= u
            (:gmtime (:timegm u))))


### PR DESCRIPTION
When replaying the README codes, I found that for me on my machine `Linux tank 6.1.35-0-lts #1-Alpine SMP PREEMPT_DYNAMIC Wed, 21 Jun 2023 22:47:07 +0000 x86_64 GNU/Linux` `update-time` call always fails with:

```
error: assert failure in val
  in put-date [date/init.janet] on line 47, column 3
  in <anonymous> [date/init.janet] on line 77, column 40
  in update-time! [date/init.janet] (tailcall) on line 69, column 14
  in _thunk [test/02-api.janet] (tailcall) on line 12, column 13
```

I have changed the test just for posteriority. I do not see anything merged :-).

The culprit of the failure is that `:isdst` is `false` in my invocation, and assert in `put-date` fails on this. I am unsure about the inner workings, but maybe `(assert (nil? ...))` would fix this situation.